### PR TITLE
Clear end of buffer when returning silence

### DIFF
--- a/source/GeoVR.Client/Audio/Audio Tree/ResourceSoundSampleProvider.cs
+++ b/source/GeoVR.Client/Audio/Audio Tree/ResourceSoundSampleProvider.cs
@@ -56,6 +56,7 @@ namespace GeoVR.Client
                 if(samplesToCopy < count)
                 {
                     //Inject a small amount of silence at the end before looping
+                    Array.Clear(buffer, (int)samplesToCopy, (int)(count - samplesToCopy));//Ensure buffer is zeroed for silence so we don't get weird artifacts - sawbe
                     samplesToCopy = count;
                 }
                 if (position > resourceSound.AudioData.Length - 1)


### PR DESCRIPTION
The weird VHF audio was caused by ResourceSoundSampleProvider not clearing the buffer it's given when reading silence (since ACBus_f32.wav is very short). This was somehow masked in the previous release by the hfWhiteNoise input being added to the mixer in CallsignSampleProvider **after** ACBus, which is no longer the case when HfSquelch is disabled in the current master.